### PR TITLE
Update/skp sdk deprecated functions

### DIFF
--- a/Morphs/Importers/Transcoders/Transcoders/Source/TranscoderSKP/ImporterSKP.cpp
+++ b/Morphs/Importers/Transcoders/Transcoders/Source/TranscoderSKP/ImporterSKP.cpp
@@ -106,7 +106,13 @@ std::shared_ptr<Asset3D> ImporterSKP::ImportToAsset3D(std::shared_ptr<std::istre
     m_progressReporter = progress;
 
     // Load the model from the buffer
-    SkpUtils::CheckResult(SUModelCreateFromBuffer(&m_suModel, data.get(), length));
+    SUModelLoadStatus m_LoadStatus;
+    SkpUtils::CheckResult(SUModelCreateFromBufferWithStatus(&m_suModel, data.get(), length, &m_LoadStatus));
+
+    if( m_LoadStatus ==  SUModelLoadStatus_Success_MoreRecent) {
+        TRACE_WARN( ImporterSKP, "Warning: Model was saved with newer version of SDK." );
+    }
+
     SkpUtils::CheckResult(SUTextureWriterCreate(&m_suTextureWriter));
     SkpUtils::CheckResult(SUModelGetRenderingOptions(m_suModel, &m_suRenderingOptions));
 

--- a/Morphs/Importers/Utils/CoreUtils/Source/ConfigurationManagerJson.cpp
+++ b/Morphs/Importers/Utils/CoreUtils/Source/ConfigurationManagerJson.cpp
@@ -394,7 +394,7 @@ namespace Babylon
                                         SetObjectValue(value, property, key);
                                         auto outputKey = LexicalCast<std::string>(key);
                                         std::string output = "WARNING: Object stored in ConfigurationManager with key<" + outputKey + "> has no value. Property has been replaced with loaded value.\n";
-                                        TRACE_IMPORTANT(ConfigurationManager, output.c_str());
+                                        TRACE_IMPORTANT(ConfigurationManager, "%s", output.c_str());
                                     }
                                 }
                             }
@@ -411,7 +411,7 @@ namespace Babylon
                             {
                                 auto outputKey = LexicalCast<std::string>(key);
                                 std::string output = "WARNING: Object stored in ConfigurationManager with key<" + outputKey + "> was not replaced by loaded configuration due to an error.\n";
-                                TRACE_IMPORTANT(ConfigurationManager, output.c_str());
+                                TRACE_IMPORTANT(ConfigurationManager, "%s", output.c_str());
                             }
                             else
                             {
@@ -441,7 +441,7 @@ namespace Babylon
                                     // If code execution reaches here then key was found, but policy is 'Add'.
                                     output = "WARNING: Property with name <" + outputKey + "> is already in configuration and load policy is 'Add', so the new value was not loaded\n";
                                 }
-                                TRACE_IMPORTANT(ConfigurationManager, output.c_str());
+                                TRACE_IMPORTANT(ConfigurationManager, "%s", output.c_str());
                             }
                         }
                     }

--- a/Morphs/Importers/Utils/Framework/Source/GeometryUtils.cpp
+++ b/Morphs/Importers/Utils/Framework/Source/GeometryUtils.cpp
@@ -367,7 +367,7 @@ namespace Babylon
             catch (GeometryProcessingException const& geomExc)
             {
                 BabylonUnusedLocal(geomExc);
-                TRACE_IMPORTANT(GeometryUtils, geomExc.m_message.c_str());
+                TRACE_IMPORTANT(GeometryUtils, "%s", geomExc.m_message.c_str());
                 completionCallback(nullptr, callbackUserData);
                 return;
             }
@@ -530,7 +530,7 @@ namespace Babylon
             catch (GeometryProcessingException const& geomExc)
             {
                 BabylonUnusedLocal(geomExc);
-                TRACE_IMPORTANT(GeometryUtils, geomExc.m_message.c_str());
+                TRACE_IMPORTANT(GeometryUtils, "%s", geomExc.m_message.c_str());
                 completionCallback(nullptr, callbackUserData);
                 return;
             }
@@ -700,7 +700,7 @@ namespace Babylon
             catch (GeometryProcessingException const& geomExc)
             {
                 BabylonUnusedLocal(geomExc);
-                TRACE_IMPORTANT(GeometryUtils, geomExc.m_message.c_str());
+                TRACE_IMPORTANT(GeometryUtils, "%s", geomExc.m_message.c_str());
                 completionCallback(nullptr, nullptr, callbackUserData);
                 return;
             }


### PR DESCRIPTION
Updated SUModelCreateFromBuffer to SUModelCreateFromBufferWithStatus since it will be deprecated in new releases of the SKP SDK. 